### PR TITLE
v1.0.4 — Switch devnet to URL-based signed Validator List

### DIFF
--- a/cfg/validators-devnet.txt
+++ b/cfg/validators-devnet.txt
@@ -1,12 +1,5 @@
-#
-# Devnet Validators (Static List)
-#
-# This file contains the public keys of trusted validators for the devnet.
-# Using static list instead of dynamic fetch for simplicity during development.
-#
+[validator_list_sites]
+https://postfiat.org/devnet_vl.json
 
-[validators]
-nHUDXa2bH68Zm5Fmg2WaDSeyEYbiqzMLXussLMyK3t6bTCNiHKY2
-nHBgo2xSUVPy4zsWb1NM7CYmyYeobx7Swa3gFgoB55ipuyJwRdKX
-nHBg5iGpnvmbckhEUkY1oTnNqr8RbzRwKyW8x5NoGJYPVT4iS7um
-nHBXSCTwVUbvZg5EAZsXXTtads2ZVd8UwLsuniGcLBgH9pP8EeBc
+[validator_list_keys]
+EDA8742E5532A51AC34A77BA1FDA86008DEAB26B321DB39D0497BFBE8465C3E2EA

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.0.3"
+char const* const versionString = "1.0.4"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
## Summary

- Switch devnet validators from a static `[validators]` block to URL-based VL fetching from `https://postfiat.org/devnet_vl.json`, verified by the devnet publisher key
- Bump version to 1.0.4

## Context

This is the M1.10.8 parity transition for the Dynamic UNL scoring pipeline. The published VL contains the same 4 foundation validator keys as the previous static config — this is a trust-mechanism change only, not a trust-set change.

Once merged, `devnet-build.yml` will produce new Docker images with the updated config. Rolling restart is handled separately: non-UNL test validators first, then foundation validators via `update.yml`.

## Key change

`cfg/validators-devnet.txt`:

```diff
-[validators]
-nHUDXa2bH68Zm5Fmg2WaDSeyEYbiqzMLXussLMyK3t6bTCNiHKY2
-nHBgo2xSUVPy4zsWb1NM7CYmyYeobx7Swa3gFgoB55ipuyJwRdKX
-nHBg5iGpnvmbckhEUkY1oTnNqr8RbzRwKyW8x5NoGJYPVT4iS7um
-nHBXSCTwVUbvZg5EAZsXXTtads2ZVd8UwLsuniGcLBgH9pP8EeBc
+[validator_list_sites]
+https://postfiat.org/devnet_vl.json
+
+[validator_list_keys]
+EDA8742E5532A51AC34A77BA1FDA86008DEAB26B321DB39D0497BFBE8465C3E2EA
```