### PR TITLE
Promote postfiatd 1.0.4 to testnet

### DIFF
--- a/cfg/validators-devnet.txt
+++ b/cfg/validators-devnet.txt
@@ -1,12 +1,5 @@
-#
-# Devnet Validators (Static List)
-#
-# This file contains the public keys of trusted validators for the devnet.
-# Using static list instead of dynamic fetch for simplicity during development.
-#
+[validator_list_sites]
+https://postfiat.org/devnet_vl.json
 
-[validators]
-nHUDXa2bH68Zm5Fmg2WaDSeyEYbiqzMLXussLMyK3t6bTCNiHKY2
-nHBgo2xSUVPy4zsWb1NM7CYmyYeobx7Swa3gFgoB55ipuyJwRdKX
-nHBg5iGpnvmbckhEUkY1oTnNqr8RbzRwKyW8x5NoGJYPVT4iS7um
-nHBXSCTwVUbvZg5EAZsXXTtads2ZVd8UwLsuniGcLBgH9pP8EeBc
+[validator_list_keys]
+EDA8742E5532A51AC34A77BA1FDA86008DEAB26B321DB39D0497BFBE8465C3E2EA

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.0.3"
+char const* const versionString = "1.0.4"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.0.2"
+char const* const versionString = "1.0.3"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.0.0"
+char const* const versionString = "1.0.1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.0.1"
+char const* const versionString = "1.0.2"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/xrpld/app/ledger/Ledger.cpp
+++ b/src/xrpld/app/ledger/Ledger.cpp
@@ -181,10 +181,10 @@ Ledger::Ledger(
     info_.closeTimeResolution = ledgerGenesisTimeResolution;
 
     // Select genesis account based on network type:
-    // - PostFiat production networks (mainnet=2026, testnet=2025, devnet=2024)
-    //   use the PostFiat genesis account UNLESS running in standalone mode
-    // - Standalone mode and unit tests: derive from "masterpassphrase"
-    //   (rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh)
+    // - PostFiat production networks (mainnet=2026, testnet=2025) use the
+    //   PostFiat genesis account UNLESS running in standalone mode
+    // - All other networks (devnet, ai-devnet, standalone, unit tests):
+    //   derive from "masterpassphrase" (rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh)
     AccountID id;
     if (config.standalone())
     {
@@ -192,9 +192,7 @@ Ledger::Ledger(
         auto const keypair = generateKeyPair(KeyType::secp256k1, seed);
         id = calcAccountID(keypair.first);
     }
-    else if (
-        config.NETWORK_ID == 2024 || config.NETWORK_ID == 2025 ||
-        config.NETWORK_ID == 2026)
+    else if (config.NETWORK_ID == 2025 || config.NETWORK_ID == 2026)
     {
         // PostFiat production networks
         id = *parseBase58<AccountID>("r4vhrMChCsaoFsBoCkRTRGUuc1njfr7bmA");

--- a/src/xrpld/app/main/Application.cpp
+++ b/src/xrpld/app/main/Application.cpp
@@ -1528,18 +1528,18 @@ ApplicationImp::setup(boost::program_options::variables_map const& cmdline)
     //
     for (auto cmd : config_->section(SECTION_RPC_STARTUP).lines())
     {
-        auto const trimmedCmd = boost::algorithm::trim_copy(cmd);
-        if (trimmedCmd.empty())
+        boost::algorithm::trim(cmd);
+        if (cmd.empty())
             continue;
 
         Json::Reader jrReader;
         Json::Value jvCommand;
 
-        if (!jrReader.parse(trimmedCmd, jvCommand))
+        if (!jrReader.parse(cmd, jvCommand))
         {
             JLOG(m_journal.error()) << "Couldn't parse entry in ["
                                     << SECTION_RPC_STARTUP << "]: '"
-                                    << trimmedCmd;
+                                    << cmd << "'";
             continue;
         }
 

--- a/src/xrpld/app/main/Application.cpp
+++ b/src/xrpld/app/main/Application.cpp
@@ -74,6 +74,7 @@
 #include <xrpl/resource/Fees.h>
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/system/error_code.hpp>
 
@@ -1527,18 +1528,24 @@ ApplicationImp::setup(boost::program_options::variables_map const& cmdline)
     //
     for (auto cmd : config_->section(SECTION_RPC_STARTUP).lines())
     {
+        auto const trimmedCmd = boost::algorithm::trim_copy(cmd);
+        if (trimmedCmd.empty())
+            continue;
+
         Json::Reader jrReader;
         Json::Value jvCommand;
 
-        if (!jrReader.parse(cmd, jvCommand))
+        if (!jrReader.parse(trimmedCmd, jvCommand))
         {
-            JLOG(m_journal.fatal()) << "Couldn't parse entry in ["
-                                    << SECTION_RPC_STARTUP << "]: '" << cmd;
+            JLOG(m_journal.error()) << "Couldn't parse entry in ["
+                                    << SECTION_RPC_STARTUP << "]: '"
+                                    << trimmedCmd;
+            continue;
         }
 
         if (!config_->quiet())
         {
-            JLOG(m_journal.fatal())
+            JLOG(m_journal.info())
                 << "Startup RPC: " << jvCommand << std::endl;
         }
 
@@ -1562,7 +1569,7 @@ ApplicationImp::setup(boost::program_options::variables_map const& cmdline)
 
         if (!config_->quiet())
         {
-            JLOG(m_journal.fatal()) << "Result: " << jvResult << std::endl;
+            JLOG(m_journal.info()) << "Result: " << jvResult << std::endl;
         }
     }
 

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -380,9 +380,17 @@ PeerImp::cluster() const
 std::string
 PeerImp::getVersion() const
 {
+    std::string version;
     if (inbound_)
-        return headers_["User-Agent"];
-    return headers_["Server"];
+        version = headers_["User-Agent"];
+    else
+        version = headers_["Server"];
+
+    static const std::string prefix = "postfiatd-";
+    if (version.substr(0, prefix.size()) == prefix)
+        version = version.substr(prefix.size());
+
+    return version;
 }
 
 Json::Value


### PR DESCRIPTION
## Summary

Promotes the current devnet release line to the `testnet` branch so the testnet Docker build workflow can publish the `1.0.4` testnet images for validators, RPC, and archive nodes.

At a high level this brings in the `postfiatd` version bump from `1.0.0` to `1.0.4`, safer startup RPC handling that logs malformed `[rpc_startup]` entries without aborting node startup, and peer version normalization so overlay JSON reports versions without the `postfiatd-` prefix.

The release also includes devnet-only operational changes: devnet genesis now uses the `masterpassphrase` account for fresh network creation, and devnet validators are configured to consume the signed validator list at `https://postfiat.org/devnet_vl.json`. These do not change the testnet validator list, testnet network ID, transaction formats, amendments, ledger object formats, or consensus rules.

This PR also aligns the `testnet` branch with `devnet` by removing the old testnet-only `docs/VALIDATOR_SETUP.md` file; current validator setup and domain/key rotation guidance lives in the maintained docs under `docs/NodeSetup.md`, `docs/ValidatorKeyUpdate.md`, and `docs/DomainAttestation.md`.